### PR TITLE
Fixes browserSync plugin issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,10 +81,10 @@ Metalsmith(__dirname)
 
     .destination('./build')
 
-    //.use(browserSync({
-      //server : "./build/",
-      //files  : ["src/**/*.md", "templates/**/*.hbs"]
-    //}))
+    .use(browserSync({
+      server : "./build/",
+      files  : ["src/**/*.md", "templates/**/*.hbs"]
+    }))
 
 
     .build(function(err, files) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-sass": "^2.0.1",
     "handlebars": "^2.0.0-alpha.2",
     "metalsmith": "^0.6.0",
-    "metalsmith-browser-sync": "^1.0.0",
+    "metalsmith-browser-sync": "git://github.com/claycarpenter/metalsmith-browser-sync.git#active-check",
     "metalsmith-collections": "^0.4.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-excerpts": "^1.0.0",


### PR DESCRIPTION
I fixed a browserSync bug a few weeks ago, and it looks like you ran into the same thing. I'm still waiting for my metalsmith-browser-sync PR to be merged so that the changes are generally available/officially published. In the meantime, I forked your repo and made the fixes to point to my fixed plugin and re-enable the browserSync integration in your build pipeline. Give it a try, it seems to be working well now for me.

Updates metalsmith-browser-sync plugin source.

Re-enables browserSync plugin in Metalsmith build pipeline.